### PR TITLE
[💻feat] DashBoard-page 마크업 구현 및 일부 설정 변경

### DIFF
--- a/src/app/dashboard-page/page.tsx
+++ b/src/app/dashboard-page/page.tsx
@@ -1,9 +1,37 @@
+import Divider from "@/components/common/divider/CommonDivider";
+import BudgetItem from "@/components/feat/budget-list/DailyBudget";
+import DonutChart from "@/components/feat/chart/DonutChart";
 import Header from "@/components/feat/header/CommonHeader";
+import MonthlyHeader from "@/components/feat/header/MonthlyHeader";
 
 export default function MainPage() {
   return (
     <div>
       <Header />
+      <div className="flex justify-center pt-20 sm:justify-start">
+        <MonthlyHeader />        
+      </div>
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <div className="flex flex-col gap-4 flex-1">
+          <div className="flex flex-col gap-4 sm:flex-row">
+            <Divider title="수입" classNames="min-w-[200px] flex-1">
+              <span className="block text-center pb-3 text-lg sm:text-xl font-semibold text-mainColor-500">200,000 원</span>
+            </Divider>
+            <Divider title="지출" classNames="min-w-[200px] flex-1">
+              <span className="block text-center pb-3 text-lg sm:text-xl font-semibold text-expense">70,000 원</span>
+            </Divider>
+          </div>
+          <Divider title="이번달의 수입/지출 내역" classNames="h-full">
+          <BudgetItem />
+          <BudgetItem />
+          <BudgetItem />
+          <BudgetItem />
+          </Divider>
+        </div>
+        <Divider title="카테고리별 지출">
+          <DonutChart />
+        </Divider>
+      </div>
     </div>
   )
 }

--- a/src/components/common/divider/CommonDivider.tsx
+++ b/src/components/common/divider/CommonDivider.tsx
@@ -1,17 +1,18 @@
 import React, { ReactNode } from 'react';
 import { cva } from 'class-variance-authority';
 
-const dividerStyles = cva('w-full my-4 p-4 bg-white shadow-sm border border-b-[0.5px] border-gray-200 rounded-md');
+const dividerStyles = cva('w-full p-4 bg-white shadow-sm border border-b-[0.5px] border-gray-200 rounded-md');
 
 interface DividerProps {
   children?: ReactNode;
   title: string;
   onClick?: () => void;
+  classNames?: string;
 }
 
-const Divider: React.FC<DividerProps> = ({ children, title }) => {
+const Divider: React.FC<DividerProps> = ({ children, title, classNames }) => {
   return (
-    <div className={`${dividerStyles()}`}>
+    <div className={`${dividerStyles()} ${classNames}`}>
       <p className='font-semibold text-base sm:text-xl mb-6'>{title}</p>
       {children}
     </div>

--- a/src/components/feat/budget-list/DailyBudget.tsx
+++ b/src/components/feat/budget-list/DailyBudget.tsx
@@ -10,7 +10,7 @@ export default function BudgetItem() {
         {/* description */}
         <span>하노이 쌀국수</span>
       </div>
-      <span className="text-[#737ABB] font-semibold">- 30,000 원</span>
+      <span className="text-expense font-semibold">- 30,000 원</span>
     </div>
   )
 }

--- a/src/components/feat/budget-list/DailyBudget.tsx
+++ b/src/components/feat/budget-list/DailyBudget.tsx
@@ -1,8 +1,8 @@
 import CategoryBadge from "../CategoryBadge";
 
-export default function BudgetList() {
+export default function BudgetItem() {
   return (
-    <div className="flex justify-between items-center pb-4 border-b border-b-gray-300 min-w-0 text-sm sm:text-base my-4 text-gray-500">
+    <div className="flex justify-between items-center pb-4 min-w-0 text-sm sm:text-base my-4 text-gray-500">
       <div className="flex justify-start items-center gap-2">
         <span>2025.08.12</span>
         {/* category-badge */}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
           500: '#81C784',
           600: "#7DC180"
         },
+        expense: "#737ABB",
       },
     },
   },


### PR DESCRIPTION
## 📍변경 사항

- [x]  feat: 신규 기능 추가
- [ ]  fix: 버그 수정
- [x]  refactor: 코드 리팩토링
- [ ]  test: 테스트 코드 추가/수정
- [x]  style: 코드 포맷팅, 스타일링 변경
- [ ]  docs: 문서 수정
- [ ]  chore: 빌드, 설정 파일 수정
- [ ]  perf: 성능 개선
- [ ]  ci: CI/CD 설정 변경
- [ ]  build: 빌드 시스템 수정
- [ ]  revert: 이전 커밋으로 되돌리기

## ⚒️작업 내역
- 대시보드 페이지 마크업 
- 반응형으로 웹/앱 동시 사용 가능하도록 구현
- 컬러 CSS config 추가
- CommonDivider 확장성을 위한 classNames 추가

## 📚다음 진행사항
- API 연동 및 목데이터 작업

### 현황
<img width="1140" height="724" alt="스크린샷 2025-07-25 오후 9 11 33" src="https://github.com/user-attachments/assets/921e13df-cf21-4413-ab92-f5a4a1338279" />

https://github.com/user-attachments/assets/81a1d25a-a55f-4939-b90e-4c52c5a9bb55


