### PR TITLE
[💻feat] 수입 / 지출 추가 modal 구현 및 추가API  구현 및 연동

### DIFF
--- a/src/api/budget.ts
+++ b/src/api/budget.ts
@@ -1,0 +1,12 @@
+import { supabase } from "@/supabase/supabaseClient";
+import { BudgetListData } from "@/types/form";
+
+export const addBudget = async (newBudget: Omit<BudgetListData, "id">) => {
+  const { data, error } = await supabase
+    .from("budgets")
+    .insert([newBudget])
+    .select();
+
+  if (error) throw error;
+  return data?.[0];
+};

--- a/src/app/budget-list/page.tsx
+++ b/src/app/budget-list/page.tsx
@@ -7,9 +7,7 @@ export default function BudgetListPage () {
   return (
     <div>
       <Header />
-      <div className="flex justify-center pt-20 sm:justify-start">
-        <MonthlyHeader />        
-      </div>
+      <MonthlyHeader />
       <div className="flex justify-between">
         <div className="text-base sm:text-lg flex gap-2 items-center">
           <FaRegMoneyBill1 className="text-mainColor-500 text-xl sm:text-2xl"/>

--- a/src/app/chart-page/page.tsx
+++ b/src/app/chart-page/page.tsx
@@ -8,9 +8,7 @@ export default function ChartPage () {
   return (
     <div>
       <Header />
-      <div className="flex justify-center pt-20 sm:justify-start">
-        <MonthlyHeader />        
-      </div>
+      <MonthlyHeader />
       <div className="flex flex-col justify-center w-full sm:w-3/4 mx-auto">
         <Divider title="카테고리별 지출">
           <DonutChart />

--- a/src/app/dashboard-page/page.tsx
+++ b/src/app/dashboard-page/page.tsx
@@ -8,9 +8,7 @@ export default function MainPage() {
   return (
     <div>
       <Header />
-      <div className="flex justify-center pt-20 sm:justify-start">
-        <MonthlyHeader />        
-      </div>
+      <MonthlyHeader />
       <div className="flex flex-col gap-4 sm:flex-row">
         <div className="flex flex-col gap-4 flex-1">
           <div className="flex flex-col gap-4 sm:flex-row">

--- a/src/components/common/input/CommonInput.tsx
+++ b/src/components/common/input/CommonInput.tsx
@@ -2,7 +2,7 @@ import { cva } from 'class-variance-authority';
 import { CommonInputProps } from '@/types/components';
 import { cn } from '@/utils/cn';
 
-const CommonInputStyle = cva('pl-3 py-3 rounded-md w-full focus:outline-none', {
+const CommonInputStyle = cva('p-3 rounded-md w-full focus:outline-none', {
   variants: {
     variant: {
       default: 'bg-white border border-solid border-border-300',

--- a/src/components/common/input/CommonSelectInput.tsx
+++ b/src/components/common/input/CommonSelectInput.tsx
@@ -1,0 +1,30 @@
+import { cva } from 'class-variance-authority';
+import { cn } from '@/utils/cn';
+import { CommonSelectProps } from '@/types/components';
+
+const CommonSelectStyle = cva(
+  'p-3 rounded-md w-full focus:outline-none bg-white border border-solid border-border-300', {
+  variants: {
+    variant: {
+      default: 'bg-white border border-solid border-border-300',
+      disabled:
+        'bg-white border border-solid border-border-300 cursor-not-allowed',
+    },
+  },
+
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export default function CommonSelect({
+  classNames,
+  children,
+  ...htmlProps
+}: CommonSelectProps) {
+  return (
+    <select className={cn(CommonSelectStyle(), classNames)} {...htmlProps}>
+      {children}
+    </select>
+  );
+}

--- a/src/components/common/modal/CommonModal.tsx
+++ b/src/components/common/modal/CommonModal.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '@/utils/cn';
+import { CommonModalProps } from '@/types/components';
+
+const modalContentStyles = cva(
+  'bg-white rounded-lg shadow-lg border-t-4 w-[90vw] max-w-[650px] m-auto border-mainColor-500 max-w-md w-full p-6 transition-transform duration-300 transform',
+  {
+    variants: {
+      isVisible: {
+        true: 'translate-y-0',
+        false: 'scale-95',
+      },
+    },
+  },
+);
+
+export default function CommonModal({
+  isOpen,
+  onClose,
+  children,
+  className,
+}: CommonModalProps) {
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsAnimating(true);
+    } else {
+      setTimeout(() => setIsAnimating(false), 300);
+    }
+  }, [isOpen]);
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 bg-black/40 z-50 flex justify-center transition-opacity duration-300',
+        isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
+        className,
+      )}
+    >
+      <div className={modalContentStyles({ isVisible: isAnimating })}>
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+        >
+          ✕ {/* 닫기 버튼 */}
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/feat/budget-list/AddBudgetModal.tsx
+++ b/src/components/feat/budget-list/AddBudgetModal.tsx
@@ -42,7 +42,7 @@ export default function AddBudgetModal({ onSubmit, isPending }: AddBudgetModalPr
           </label>
         </div>
         <ValidationError error={errors.budget_type?.message} />
-
+        {/* TODO: 나중에 공통 컴포넌트 분리 */}
         {/* 날짜 */}
         <label className="text-sm font-bold text-mainColor-500 pt-1">일자</label>
         <CommonInput

--- a/src/components/feat/budget-list/AddBudgetModal.tsx
+++ b/src/components/feat/budget-list/AddBudgetModal.tsx
@@ -1,0 +1,15 @@
+
+import CommonModal from "@/components/common/modal/CommonModal";
+import { useModalStore } from "@/store/modalStore";
+
+export default function AddBudgetModal() {
+  const { isAddBudgetModalOpen, closeAddBudgetModal } = useModalStore();
+
+  return (
+    <>
+      <CommonModal isOpen={isAddBudgetModalOpen} onClose={closeAddBudgetModal}>
+        <div className="p-8">모달입니다 모달이에요!</div>
+      </CommonModal>
+    </>
+  );
+}

--- a/src/components/feat/budget-list/AddBudgetModal.tsx
+++ b/src/components/feat/budget-list/AddBudgetModal.tsx
@@ -1,15 +1,94 @@
+'use client';
 
+import { useForm } from "react-hook-form";
+import CommonButton from "@/components/common/button/CommonButton";
+import CommonInput from "@/components/common/input/CommonInput";
+import CommonSelectInput from "@/components/common/input/CommonSelectInput";
 import CommonModal from "@/components/common/modal/CommonModal";
+import { CATEGORY_OPTIONS } from "@/constants/categoryOptions";
 import { useModalStore } from "@/store/modalStore";
+import { BudgetListData } from "@/types/form";
+import ValidationError from "../auth/ValidationError";
 
-export default function AddBudgetModal() {
+interface AddBudgetModalProps {
+  onSubmit: (data: Omit<BudgetListData, "id">) => void;
+  isPending?: boolean;
+}
+
+export default function AddBudgetModal({ onSubmit, isPending }: AddBudgetModalProps) {
   const { isAddBudgetModalOpen, closeAddBudgetModal } = useModalStore();
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<BudgetListData>({
+    mode: "onChange",
+  });
+
+  const handleFormSubmit = (data: Omit<BudgetListData, "id">) => {
+    onSubmit(data);
+    reset();
+    closeAddBudgetModal();
+  };
 
   return (
-    <>
-      <CommonModal isOpen={isAddBudgetModalOpen} onClose={closeAddBudgetModal}>
-        <div className="p-8">모달입니다 모달이에요!</div>
-      </CommonModal>
-    </>
+    <CommonModal isOpen={isAddBudgetModalOpen} onClose={closeAddBudgetModal}>
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-4 p-4 w-full min-w-[220px] max-w-[350px] mx-auto">
+        {/* 수입/지출 라디오 */}
+        <div className="flex gap-3">
+          <label className="flex items-center gap-1">
+            <input type="radio" value="income" {...register("budget_type", { required: "‼️ 수입/지출을 선택해 주세요." })} />
+            <span>수입</span>
+          </label>
+          <label className="flex items-center gap-1">
+            <input type="radio" value="expense" {...register("budget_type", { required: "‼️ 수입/지출을 선택해 주세요." })} />
+            <span>지출</span>
+          </label>
+        </div>
+        <ValidationError error={errors.budget_type?.message} />
+
+        {/* 날짜 */}
+        <label className="text-sm font-bold text-mainColor-500 pt-1">일자</label>
+        <CommonInput
+          type="date"
+          {...register("date", { required: "‼️ 날짜를 입력해 주세요." })}
+        />
+        <ValidationError error={errors.date?.message} />
+
+        {/* 카테고리 셀렉트 */}
+        <label className="text-sm font-bold text-mainColor-500 pt-1">카테고리</label>
+        <CommonSelectInput
+          {...register("category", { required: "‼️ 카테고리를 선택해 주세요." })}
+        >
+          <option value="">카테고리 선택</option>
+          {CATEGORY_OPTIONS.map(({ value, label }) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
+        </CommonSelectInput>
+        <ValidationError error={errors.category?.message} />
+
+        {/* 금액 */}
+        <label className="text-sm font-bold text-mainColor-500 pt-1">금액</label>
+        <CommonInput
+          type="number"
+          min={1}
+          {...register("amount", {
+            required: "‼️ 금액을 입력해 주세요.",
+            min: { value: 1, message: "‼️ 1원 이상 입력해 주세요." },
+            valueAsNumber: true,
+          })}
+        />
+        <ValidationError error={errors.amount?.message} />
+
+        {/* 설명 */}
+        <label className="text-sm font-bold text-mainColor-500 pt-1">설명</label>
+        <CommonInput
+          type="text"
+          {...register("description")}
+          placeholder="설명"
+        />
+        <ValidationError error={errors.description?.message} />
+        {/* 버튼 */}
+        <CommonButton type="submit" classNames="bg-mainColor-500 hover:bg-mainColor-600 text-white">
+          {isPending ? "등록 중..." : "등록하기"}
+        </CommonButton>
+      </form>
+    </CommonModal>
   );
 }

--- a/src/components/feat/header/CommonHeader.tsx
+++ b/src/components/feat/header/CommonHeader.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useSignOut } from "@/hooks/useSign";
+import { useModalStore } from "@/store/modalStore";
 import Link from "next/link";
-import { FaChartColumn, FaArrowRightFromBracket, FaList } from "react-icons/fa6";
+import { FaChartColumn, FaArrowRightFromBracket, FaList, FaRegSquarePlus } from "react-icons/fa6";
+import AddBudgetModal from "../budget-list/AddBudgetModal";
 
 export default function Header() {
+  const { openAddBudgetModal } = useModalStore();
   const { mutate: signOut } = useSignOut();
   const icons = [
   { icon: <FaChartColumn />, href: "/chart-page" },
@@ -12,25 +15,29 @@ export default function Header() {
 ];
 
   return (
-    <div className="fixed inset-x-0 top-0 w-full z-50">
-      <div className="flex items-center bg-mainColor-300 justify-between h-20 px-3 sm:px-6">
-        <div className="hidden sm:block w-20" />
-        <div className="flex-1 flex sm:justify-center justify-start min-w-[120px] sm:min-w-[180px]">
-          <img
-            src="/PinnBB-Logo.png"
-            alt="PinnBB Logo"
-            className="w-[120px] sm:w-[180px] h-auto mr-2 sm:mr-0"
-          />
-        </div>
-        <div className=" flex gap-2 sm:gap-5 text-mainColor-500 text-xl sm:text-2xl cursor-pointer mt-8">
-          {icons.map(({ icon, href }, idx) => (
-            <Link key={href} href={href}>
-              {icon}
-            </Link>
-          ))}
-          <FaArrowRightFromBracket onClick={() => signOut()}/> 
+    <>
+      <div className="fixed inset-x-0 top-0 w-full">
+        <div className="flex items-center bg-mainColor-300 justify-between h-20 px-3 sm:px-6">
+          <div className="hidden sm:block w-20" />
+          <div className="flex-1 flex sm:justify-center justify-start min-w-[120px] sm:min-w-[180px]">
+            <img
+              src="/PinnBB-Logo.png"
+              alt="PinnBB Logo"
+              className="w-[120px] sm:w-[180px] h-auto mr-2 sm:mr-0"
+            />
+          </div>
+          <div className="flex gap-2 sm:gap-5 text-mainColor-500 text-xl sm:text-2xl cursor-pointer mt-8">
+            <FaRegSquarePlus onClick={openAddBudgetModal} className="hover:text-mainColor-600" />
+            {icons.map(({ icon, href }) => (
+              <Link key={href} href={href}>
+                {icon}
+              </Link>
+            ))}
+            <FaArrowRightFromBracket onClick={() => signOut()} />
+          </div>
         </div>
       </div>
-    </div>
+      <AddBudgetModal />
+    </>
   );
 }

--- a/src/components/feat/header/CommonHeader.tsx
+++ b/src/components/feat/header/CommonHeader.tsx
@@ -5,14 +5,27 @@ import { useModalStore } from "@/store/modalStore";
 import Link from "next/link";
 import { FaChartColumn, FaArrowRightFromBracket, FaList, FaRegSquarePlus } from "react-icons/fa6";
 import AddBudgetModal from "../budget-list/AddBudgetModal";
+import { BudgetListData } from "@/types/form";
+import { toast } from "sonner";
+import { useAddBudget } from "@/hooks/useBudget";
 
 export default function Header() {
   const { openAddBudgetModal } = useModalStore();
   const { mutate: signOut } = useSignOut();
+  const { mutate: addBudget, isPending } = useAddBudget();
+
   const icons = [
   { icon: <FaChartColumn />, href: "/chart-page" },
   { icon: <FaList />, href: "/budget-list" },
 ];
+
+  const handleAddBudget = (data: Omit<BudgetListData, "id">) => {
+    addBudget(data, {
+      onSuccess: () => toast.success("등록에 성공하였습니다 💸"),
+      onError: (err) => toast.error("등록에 실패하였습니다 💦" + err.message),
+    });
+  };
+
 
   return (
     <>
@@ -37,7 +50,7 @@ export default function Header() {
           </div>
         </div>
       </div>
-      <AddBudgetModal />
+      <AddBudgetModal onSubmit={handleAddBudget} isPending={isPending} />
     </>
   );
 }

--- a/src/components/feat/header/MonthlyHeader.tsx
+++ b/src/components/feat/header/MonthlyHeader.tsx
@@ -26,14 +26,16 @@ export default function MonthlyHeader({ onMonthChange }: MonthlyHeaderProps) {
   
   // TODO: Mockup 테스트 후 props 받도록 수정
   return (
-    <div className="flex items-center justify-center gap-3 py-3 text-base sm:text-xl font-medium">
-      <button onClick={goPrevMonth} className="text-mainColor-500 text-xl px-2">
-        <FaAngleLeft />
-      </button>
-      <span>{monthText}</span>
-      <button onClick={goNextMonth} className="text-mainColor-500 text-2xl px-2">
-        <FaAngleRight />
-      </button>
+    <div className="flex pt-20 justify-between items-center text-xl sm:text-2xl cursor-pointer">
+      <div className="flex items-center justify-center gap-3 py-3 text-base sm:text-xl font-medium">
+        <button onClick={goPrevMonth} className="text-mainColor-500 px-2">
+          <FaAngleLeft />
+        </button>
+        <span>{monthText}</span>
+        <button onClick={goNextMonth} className="text-mainColor-500 px-2">
+          <FaAngleRight />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/constants/categoryOptions.ts
+++ b/src/constants/categoryOptions.ts
@@ -1,0 +1,12 @@
+import { BudgetCategory } from "@/types/form";
+
+export const CATEGORY_OPTIONS: { value: BudgetCategory; label: string, color?: string; }[] = [
+  { value: "food", label: "식비", color: "#8C81C7" },
+  { value: "etc", label: "기타", color: "#819BC7" },
+  { value: "transport", label: "교통", color: "#FDA760" },
+  { value: "health", label: "의료/건강", color: "#F2EF97" },
+  { value: "salary", label: "월급", color: "#81C784" },
+  { value: "living", label: "생활비", color: "#81C7C3" },
+  { value: "allowance", label: "용돈", color: "#F7ABBE" },
+  { value: "culture", label: "문화/여가", color: "#C781B9" },
+];

--- a/src/hooks/useBudget.ts
+++ b/src/hooks/useBudget.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { addBudget } from "@/api/budget";
+import { BudgetListData } from "@/types/form";
+
+export function useAddBudget() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (newBudget: Omit<BudgetListData, "id">) => addBudget(newBudget),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["budgets"] });
+    },
+  });
+}

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface ModalState {
+  isAddBudgetModalOpen: boolean;
+  openAddBudgetModal: () => void;
+  closeAddBudgetModal: () => void;
+}
+
+export const useModalStore = create<ModalState>((set) => ({
+  isAddBudgetModalOpen: false,
+  openAddBudgetModal: () => set({ isAddBudgetModalOpen: true }),
+  closeAddBudgetModal: () => set({ isAddBudgetModalOpen: false }),
+}));

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -32,3 +32,10 @@ export interface SignUpData extends SignInData {
   nickName?: string;
   tel?: string;
 }
+
+export interface CommonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  className?: string;
+}

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, SelectHTMLAttributes } from "react";
 
 export type ButtonType = 'button' | 'submit' | 'reset';
 
@@ -12,7 +12,7 @@ export interface ButtonProps
   variant?: 'default';
 }
 
-export type InputType = 'text' | 'password' | 'email' | 'date' | 'number' | 'tel' | 'name' | 'passwordCheck';
+export type InputType = 'text' | 'password' | 'email' | 'date' | 'number' | 'tel' | 'name' | 'passwordCheck' | 'select';
 export interface CommonInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   type: InputType;
@@ -38,4 +38,9 @@ export interface CommonModalProps {
   onClose: () => void;
   children: React.ReactNode;
   className?: string;
+}
+
+export interface CommonSelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  classNames?: string;
+  children?: React.ReactNode;
 }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -5,7 +5,7 @@ export type BudgetCategory =
 
 export interface BudgetListData {
   id: number;
-  budgetType: BudgetType;
+  budget_type: BudgetType;
   description: string;
   category: BudgetCategory;
   date: string;      // ISO 문자열 대비


### PR DESCRIPTION
## 📍변경 사항

- [x]  feat: 신규 기능 추가
- [x]  fix: 버그 수정
- [x]  refactor: 코드 리팩토링
- [ ]  test: 테스트 코드 추가/수정
- [x]  style: 코드 포맷팅, 스타일링 변경
- [ ]  docs: 문서 수정
- [ ]  chore: 빌드, 설정 파일 수정
- [ ]  perf: 성능 개선
- [ ]  ci: CI/CD 설정 변경
- [ ]  build: 빌드 시스템 수정
- [ ]  revert: 이전 커밋으로 되돌리기

## ⚒️작업 내역
- 공통으로 사용 가능한 CommonModal 컴포넌트 구현
- zustand를 활용하여 전역으로 상태 관리하도록 구현
- CommonModal 을 기반으로 하는 수입/지출 등록 폼 모달 구현
- CommonInput 내의 select type 분기(확장성 고려)
- supabase와 react-query를 활용한 등록 훅 / API 구현 및 연동
- RHF(React-Hook-Form)을 활용한 유효성 검증 추가
- 차후 리팩토링 필요부분 주석 추가

## 📚다음 진행사항
- 필요한 더미데이터 반영 및 리스트 불러오는 훅 연동
- 불러온 데이터 기반으로 차트 생성 연동
- 사용자 로그인 여부 상태관리 추가

### 현황

https://github.com/user-attachments/assets/1a533d33-c1f7-4417-a4d4-369bc3780ab5

